### PR TITLE
Refactor phone and email mapping in Contact model

### DIFF
--- a/lib/src/models/contact_model.dart
+++ b/lib/src/models/contact_model.dart
@@ -51,6 +51,18 @@ class Contact {
   }
 
   factory Contact.fromMap(Map<String, dynamic> map) {
+    List<String> listStringFrom(List<dynamic> list) {
+      if (list.isEmpty) return [];
+      return list
+          .map((e) {
+            if (e is String) return e;
+            if (e is Map) return e['value'];
+            return null;
+          })
+          .whereType<String>()
+          .toList();
+    }
+    
     return Contact(
       id: map['id'],
       displayName: map['displayName'],
@@ -59,8 +71,8 @@ class Contact {
       familyName: map['familyName'],
       prefix: map['prefix'],
       suffix: map['suffix'],
-      phones: List<String>.from(map['phones'] ?? []),
-      emails: List<String>.from(map['emails'] ?? []),
+      phones:listStringFrom(map['phones'] ?? []),
+      emails: listStringFrom(map['emails'] ?? []),
       company: map['company'],
       jobTitle: map['jobTitle'],
       photo: map['photo'],


### PR DESCRIPTION
Thank you for your package.
The List.String parsing breaks on newer versions of iOS, because the map is built a bit differently. The phone numbers and emails have a {value: "XXX", label: "XXX"} map, instead of a list of strings.

I also added a fix for the missing offset and batchSize parameters in the swift code (courtesy of GPT-5 Copilot)

Would appreciate it if you get a chance to test this.